### PR TITLE
导出对话框新增可滚动的对话选择区

### DIFF
--- a/chatgpt-exporter.user.js
+++ b/chatgpt-exporter.user.js
@@ -1,5 +1,5 @@
 // ==UserScript==
-// @name         ChatGPT Universal Exporter Enhanced (enhanced)
+// @name         ChatGPT Universal Exporter Enhanced (Fixed)
 // @description  Robust ZIP exporter with JSON/Markdown/HTML, safer intercept, full-thread export, and retries.
 // @match        https://chatgpt.com/*
 // @match        https://chat.openai.com/*


### PR DESCRIPTION
导出对话框新增可滚动的对话选择区：支持刷新列表、全选/单选，项目分组折叠显示（一级标题项目名，展开后子项右侧有勾选框），空项目不展示，项目分组置顶并保持加载顺序。 导出流程改为按用户勾选的对话执行，根目录和项目对话分目录写入 ZIP；未选中则阻止导出。
模式区分强化：个人模式仅加载个人对话，团队模式仅加载指定 Team Workspace 的对话；检测到团队 ID 时默认选中团队模式，但团队输入区始终可见以便手动输入。 UI 提示与状态：显示加载进度/失败提示，缓存列表避免重复拉取；按钮文案随进度更新。